### PR TITLE
msm: vidc: reduce max_packets count to 480

### DIFF
--- a/drivers/media/platform/msm/vidc/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc/venus_hfi.c
@@ -80,7 +80,7 @@ const struct msm_vidc_gov_data DEFAULT_BUS_VOTE = {
 	.data_count = 0,
 };
 
-const int max_packets = 1000;
+const int max_packets = 480; /* 16 sessions x 30 packets */
 
 static void venus_hfi_pm_handler(struct work_struct *work);
 static DECLARE_DELAYED_WORK(venus_hfi_pm_work, venus_hfi_pm_handler);


### PR DESCRIPTION
Currently max_packets is configured as 1000, but max outstanding
packets will not exceed more than 480(16 clients x 30 pkts/client).

Bug: 153501065
Test: camera recording/video playback
Change-Id: I57a302857ce143c8c7507818e6e9e9ed1e29f327
Signed-off-by: wenchangliu <wenchangliu@google.com>